### PR TITLE
unconfuse quoting in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,7 +703,7 @@ if (UNIX)
 # Generate and install pkgconfig.
 # (This is not indented, because the tabs will be part of the output)
 file(WRITE "${PROJECT_BINARY_DIR}/libwebsockets.pc"
-"prefix="${CMAKE_INSTALL_PREFIX}"
+"prefix=\"${CMAKE_INSTALL_PREFIX}\"
 exec_prefix=\${prefix}
 libdir=\${exec_prefix}/lib${LIB_SUFFIX}
 includedir=\${prefix}/include


### PR DESCRIPTION
Removed Cmake Warning "Argument not separated from preceding token by whitespace."