### PR TITLE
Remove an unused 'decode' variable

### DIFF
--- a/lib/base64-decode.c
+++ b/lib/base64-decode.c
@@ -45,8 +45,6 @@
 
 static const char encode[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 			     "abcdefghijklmnopqrstuvwxyz0123456789+/";
-static const char decode[] = "|$$$}rstuvwxyz{$$$$$$$>?@ABCDEFGHIJKLMNOPQRSTUVW"
-			     "$$$$$$XYZ[\\]^_`abcdefghijklmnopq";
 
 LWS_VISIBLE int
 lws_b64_encode_string(const char *in, int in_len, char *out, int out_size)


### PR DESCRIPTION
This was causing gcc to emit an unused-const-variable warning.

See also https://github.com/scanlime/fadecandy/issues/113